### PR TITLE
Smaller fixes

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -93,7 +93,7 @@ func parseMessage(msg amqp.Delivery) {
 		SchemaVersion:     "1",
 		UserId:            1,
 		SourceId:          1,
-		ServiceName:       strings.SplitN(msg.RoutingKey, ".", 1)[0],
+		ServiceName:       strings.SplitN(msg.RoutingKey, ".", 2)[0],
 		ServiceVersion:    "NotSend",
 		ServiceConfig:     "NotSend",
 		ObjectCategory:    "NotSend",

--- a/defaultCollections.go
+++ b/defaultCollections.go
@@ -1,5 +1,9 @@
 package main
 
+import (
+//	"encoding/json"
+)
+
 /*
 This file contains structs to represent all default
 collections.
@@ -7,10 +11,6 @@ If you need to extend these for your database specific
 implementation add a wrapper to your storer*.go file,
 don't change these structs here!
 */
-
-import (
-	"encoding/json"
-)
 
 type dbObjects struct {
 	SHA256 string `json:"sha256"`
@@ -33,19 +33,19 @@ type dbSamples struct {
 }
 
 type dbResults struct {
-	Id                string          `json:"_id"`
-	SHA256            string          `json:"sha256"`
-	SchemaVersion     string          `json:"schema_version"`
-	UserId            int             `json:"user_id"`
-	SourceId          int             `json:"source_id"`
-	ServiceName       string          `json:"service_name"`
-	ServiceVersion    string          `json:"service_version"`
-	ServiceConfig     string          `json:"service_config"`
-	ObjectCategory    string          `json:"object_category"`
-	ObjectType        string          `json:"object_type"`
-	Results           json.RawMessage `json:"results"`
-	Date              string          `json:"date"`
-	WatchguardStatus  string          `json:"watchguard_status"`
-	WatchguardLog     []string        `json:"watchguard_log"`
-	WatchguardVersion string          `json:"watchguard_version"`
+	Id                string                 `json:"_id"`
+	SHA256            string                 `json:"sha256"`
+	SchemaVersion     string                 `json:"schema_version"`
+	UserId            int                    `json:"user_id"`
+	SourceId          int                    `json:"source_id"`
+	ServiceName       string                 `json:"service_name"`
+	ServiceVersion    string                 `json:"service_version"`
+	ServiceConfig     string                 `json:"service_config"`
+	ObjectCategory    string                 `json:"object_category"`
+	ObjectType        string                 `json:"object_type"`
+	Results           map[string]interface{} `json:"results"`
+	Date              string                 `json:"date"`
+	WatchguardStatus  string                 `json:"watchguard_status"`
+	WatchguardLog     []string               `json:"watchguard_log"`
+	WatchguardVersion string                 `json:"watchguard_version"`
 }

--- a/defaultCollections.go
+++ b/defaultCollections.go
@@ -8,6 +8,10 @@ implementation add a wrapper to your storer*.go file,
 don't change these structs here!
 */
 
+import (
+	"encoding/json"
+)
+
 type dbObjects struct {
 	SHA256 string `json:"sha256"`
 	SHA1   string `json:"sha1"`
@@ -29,19 +33,19 @@ type dbSamples struct {
 }
 
 type dbResults struct {
-	Id                string   `json:"_id"`
-	SHA256            string   `json:"sha256"`
-	SchemaVersion     string   `json:"schema_version"`
-	UserId            int      `json:"user_id"`
-	SourceId          int      `json:"source_id"`
-	ServiceName       string   `json:"service_name"`
-	ServiceVersion    string   `json:"service_version"`
-	ServiceConfig     string   `json:"service_config"`
-	ObjectCategory    string   `json:"object_category"`
-	ObjectType        string   `json:"object_type"`
-	Results           string   `json:"results"`
-	Date              string   `json:"date"`
-	WatchguardStatus  string   `json:"watchguard_status"`
-	WatchguardLog     []string `json:"watchguard_log"`
-	WatchguardVersion string   `json:"watchguard_version"`
+	Id                string          `json:"_id"`
+	SHA256            string          `json:"sha256"`
+	SchemaVersion     string          `json:"schema_version"`
+	UserId            int             `json:"user_id"`
+	SourceId          int             `json:"source_id"`
+	ServiceName       string          `json:"service_name"`
+	ServiceVersion    string          `json:"service_version"`
+	ServiceConfig     string          `json:"service_config"`
+	ObjectCategory    string          `json:"object_category"`
+	ObjectType        string          `json:"object_type"`
+	Results           json.RawMessage `json:"results"`
+	Date              string          `json:"date"`
+	WatchguardStatus  string          `json:"watchguard_status"`
+	WatchguardLog     []string        `json:"watchguard_log"`
+	WatchguardVersion string          `json:"watchguard_version"`
 }

--- a/defaultCollections.go
+++ b/defaultCollections.go
@@ -1,9 +1,5 @@
 package main
 
-import (
-//	"encoding/json"
-)
-
 /*
 This file contains structs to represent all default
 collections.

--- a/storerMongoDB.go
+++ b/storerMongoDB.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	//	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -218,8 +217,6 @@ func (s storerMongoDB) StoreResult(result *dbResults) error {
 		WatchguardLog:     result.WatchguardLog,
 		WatchguardVersion: result.WatchguardVersion,
 	}
-
-	debug.Printf("%v", resultsM)
 
 	if err := s.DB.C("results").Insert(resultsM); err != nil {
 		return err

--- a/storerMongoDB.go
+++ b/storerMongoDB.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	//	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,21 +30,21 @@ type dbSamplesMongodb struct {
 }
 
 type dbResultsMongodb struct {
-	Id                bson.ObjectId `json:"_id" bson:"_id,omitempty"`
-	SHA256            string        `json:"sha256"`
-	SchemaVersion     string        `json:"schema_version"`
-	UserId            int           `json:"user_id"`
-	SourceId          int           `json:"source_id"`
-	ServiceName       string        `json:"service_name"`
-	ServiceVersion    string        `json:"service_version"`
-	ServiceConfig     string        `json:"service_config"`
-	ObjectCategory    string        `json:"object_category"`
-	ObjectType        string        `json:"object_type"`
-	Results           string        `json:"results"`
-	Date              string        `json:"date"`
-	WatchguardStatus  string        `json:"watchguard_status"`
-	WatchguardLog     []string      `json:"watchguard_log"`
-	WatchguardVersion string        `json:"watchguard_version"`
+	Id                bson.ObjectId          `json:"_id" bson:"_id,omitempty"`
+	SHA256            string                 `json:"sha256"`
+	SchemaVersion     string                 `json:"schema_version"`
+	UserId            int                    `json:"user_id"`
+	SourceId          int                    `json:"source_id"`
+	ServiceName       string                 `json:"service_name"`
+	ServiceVersion    string                 `json:"service_version"`
+	ServiceConfig     string                 `json:"service_config"`
+	ObjectCategory    string                 `json:"object_category"`
+	ObjectType        string                 `json:"object_type"`
+	Results           map[string]interface{} `json:"results"`
+	Date              string                 `json:"date"`
+	WatchguardStatus  string                 `json:"watchguard_status"`
+	WatchguardLog     []string               `json:"watchguard_log"`
+	WatchguardVersion string                 `json:"watchguard_version"`
 }
 
 func (s storerMongoDB) Initialize(c []*dbConnector) (Storer, error) {
@@ -217,6 +218,8 @@ func (s storerMongoDB) StoreResult(result *dbResults) error {
 		WatchguardLog:     result.WatchguardLog,
 		WatchguardVersion: result.WatchguardVersion,
 	}
+
+	debug.Printf("%v", resultsM)
 
 	if err := s.DB.C("results").Insert(resultsM); err != nil {
 		return err


### PR DESCRIPTION
Some smaller fixes, the incoming results from totem are now expanded and saved as pure json instead of a string of encoded json. Also the name of the service is now extracted correctly without ".result.static.totem" appended.