### PR TITLE
added tags to results

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -10,11 +10,12 @@ import (
 )
 
 type totemResult struct {
-	Filename string `json:"filename"`
-	Data     string `json:"data"`
-	MD5      string `json:"md5"`
-	SHA1     string `json:"sha1"`
-	SHA256   string `json:"sha256"`
+	Filename string   `json:"filename"`
+	Data     string   `json:"data"`
+	Tags     []string `json:"tags"`
+	MD5      string   `json:"md5"`
+	SHA1     string   `json:"sha1"`
+	SHA256   string   `json:"sha256"`
 }
 
 func initAMQP(connect, queue, routingKey string, prefetchCount int) {
@@ -111,6 +112,7 @@ func parseMessage(msg amqp.Delivery) {
 		ObjectCategory:    "NotSend",
 		ObjectType:        "sample",
 		Results:           resData,
+		Tags:              m.Tags,
 		Date:              fmt.Sprintf("%v", time.Now().Format(time.RFC3339)),
 		WatchguardStatus:  "NotImplemented",
 		WatchguardLog:     []string{"NotImplemented"},

--- a/defaultCollections.go
+++ b/defaultCollections.go
@@ -40,6 +40,7 @@ type dbResults struct {
 	ObjectCategory    string                 `json:"object_category"`
 	ObjectType        string                 `json:"object_type"`
 	Results           map[string]interface{} `json:"results"`
+	Tags              []string               `json:"tags"`
 	Date              string                 `json:"date"`
 	WatchguardStatus  string                 `json:"watchguard_status"`
 	WatchguardLog     []string               `json:"watchguard_log"`

--- a/storerMongoDB.go
+++ b/storerMongoDB.go
@@ -40,6 +40,7 @@ type dbResultsMongodb struct {
 	ObjectCategory    string                 `json:"object_category"`
 	ObjectType        string                 `json:"object_type"`
 	Results           map[string]interface{} `json:"results"`
+	Tags              []string               `json:"tags"`
 	Date              string                 `json:"date"`
 	WatchguardStatus  string                 `json:"watchguard_status"`
 	WatchguardLog     []string               `json:"watchguard_log"`
@@ -212,6 +213,7 @@ func (s storerMongoDB) StoreResult(result *dbResults) error {
 		ObjectCategory:    result.ObjectCategory,
 		ObjectType:        result.ObjectType,
 		Results:           result.Results,
+		Tags:              result.Tags,
 		Date:              result.Date,
 		WatchguardStatus:  result.WatchguardStatus,
 		WatchguardLog:     result.WatchguardLog,
@@ -246,6 +248,7 @@ func (s storerMongoDB) GetResult(id string) (*dbResults, error) {
 		ObjectCategory:    result.ObjectCategory,
 		ObjectType:        result.ObjectType,
 		Results:           result.Results,
+		Tags:              result.Tags,
 		Date:              result.Date,
 		WatchguardStatus:  result.WatchguardStatus,
 		WatchguardLog:     result.WatchguardLog,


### PR DESCRIPTION
Addes tags to results. If totem adds a result it can now add tags to the json message in the form of:
```tags: ["tag1", "tag2"]```

These will then be added to the result for faster searching. (See #2 for additional information)