### PR TITLE
Added local-fs object storage + Patch for running both setups in one go

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerS3"
+	"github.com/HolmesProcessing/Holmes-Storage/objStorerLocalFS"
 	"github.com/HolmesProcessing/Holmes-Storage/storerCassandra"
 	"github.com/HolmesProcessing/Holmes-Storage/storerGeneric"
 	"github.com/HolmesProcessing/Holmes-Storage/storerMongoDB"
@@ -94,8 +95,8 @@ func main() {
 	switch conf.ObjStorage {
 	case "S3":
 		objStorer = &ObjStorerS3.ObjStorerS3{}
-	//case "local-fs":
-	//	mainStorer = &objStorerLocalFS{}
+	case "local-fs":
+		objStorer = &ObjStorerLocalFS.ObjStorerLocalFS{}
 	default:
 		warning.Panicln("Please supply a valid object storage engine!")
 	}
@@ -115,7 +116,6 @@ func main() {
 		}
 
 		info.Println("Database was setup without errors.")
-		return // we don't want to execute this any further
 	}
 
 	if objSetup {
@@ -125,6 +125,9 @@ func main() {
 		}
 
 		info.Println("Object storage was setup without errors.")
+	}
+	
+	if setup || objSetup {
 		return // we don't want to execute this any further
 	}
 

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -1,0 +1,43 @@
+package ObjStorerLocalFS
+
+import (
+	"io/ioutil"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
+)
+
+type ObjStorerLocalFS struct {
+	StorageLocation string
+}
+
+func (s ObjStorerLocalFS) Initialize(c []*objStorerGeneric.ObjDBConnector) (objStorerGeneric.ObjStorer, error) {
+	s.StorageLocation = "./objstorage-local-fs"
+	return s, nil
+}
+
+func (s ObjStorerLocalFS) Setup() error {
+	err := os.Mkdir(s.StorageLocation, 0644)
+	return err
+}
+
+func (s ObjStorerLocalFS) StoreSample(sample *objStorerGeneric.Sample) error {
+	filepath := fmt.Sprintf("%s/%s",s.StorageLocation,sample.SHA256)
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return ioutil.WriteFile(filepath, sample.Data, 0644)
+	} else {
+		return errors.New("duplicate")
+	}
+}
+
+func (s ObjStorerLocalFS) GetSample(id string) (*objStorerGeneric.Sample, error) {
+	sample := &objStorerGeneric.Sample{SHA256: id}
+	filepath := fmt.Sprintf("%s/%s",s.StorageLocation, sample.SHA256)
+	data, err := ioutil.ReadFile(filepath)
+	sample.Data = data
+	return sample, err
+}
+
+// TODO: Support MultipleObjects retrieval and getting. Useful when using something over 100megs

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -3,8 +3,9 @@ package ObjStorerLocalFS
 import (
 	"io/ioutil"
 	"errors"
-	"fmt"
 	"os"
+	"path/filepath"
+	"bytes"
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
 )
@@ -13,13 +14,50 @@ type ObjStorerLocalFS struct {
 	StorageLocation string
 }
 
-func (s ObjStorerLocalFS) Initialize(c []*objStorerGeneric.ObjDBConnector) (objStorerGeneric.ObjStorer, error) {
-	s.StorageLocation = "./objstorage-local-fs"
+func (s ObjStorerLocalFS) Initialize(configs []*objStorerGeneric.ObjDBConnector) (objStorerGeneric.ObjStorer, error) {
+	// check for storage location setting
+	// re-using the Bucket setting, local-fs is not the preferred storage method
+	// and as such we don't encourage it by adding a dedicated setting
+	if len(configs) > 0 && configs[0].Bucket != "" {
+		s.StorageLocation = configs[0].Bucket
+	} else {
+		s.StorageLocation = "./objstorage-local-fs"
+	}
+	
+	// setup storage location if not exists
+	if err := s.Setup(); err != nil {
+		return s, err
+	}
+	
+	// create a temporary file to test writing + reading
+	data := []byte("test content")
+	path := filepath.Join(s.StorageLocation, "tempfile")
+	
+	// test writing
+	if err := ioutil.WriteFile(path, data, 0644); err != nil {
+		os.Remove(path)
+		return s, err
+	}
+	
+	// test reading
+	if data2, err := ioutil.ReadFile(path); err != nil {
+		os.Remove(path)
+		return s, err
+	} else if !bytes.Equal(data, data2) {
+		os.Remove(path)
+		return s, errors.New("tempfile write/read failed, data mismatch")
+	}
+	
+	// test removal
+	if err := os.Remove(path); err != nil {
+		return s, err
+	}
+	
 	return s, nil
 }
 
 func (s ObjStorerLocalFS) Setup() error {
-	err := os.Mkdir(s.StorageLocation, 0755)
+	err := os.MkdirAll(s.StorageLocation, 0755)
 	if err != nil {
 		return err
 	}
@@ -28,13 +66,13 @@ func (s ObjStorerLocalFS) Setup() error {
 }
 
 func (s ObjStorerLocalFS) StoreSample(sample *objStorerGeneric.Sample) error {
-	filepath := fmt.Sprintf("%s/%s",s.StorageLocation,sample.SHA256)
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		return ioutil.WriteFile(filepath, sample.Data, 0644)
+	path := filepath.Join(s.StorageLocation, sample.SHA256)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return ioutil.WriteFile(path, sample.Data, 0644)
 	} else if os.IsPermission(err) {
 		return errors.New("permission denied")
 	} else if os.IsExist(err) {
-		return errors.New("duplicate")
+		return nil  // duplicates are fine
 	} else {
 		return err
 	}
@@ -42,8 +80,8 @@ func (s ObjStorerLocalFS) StoreSample(sample *objStorerGeneric.Sample) error {
 
 func (s ObjStorerLocalFS) GetSample(id string) (*objStorerGeneric.Sample, error) {
 	sample := &objStorerGeneric.Sample{SHA256: id}
-	filepath := fmt.Sprintf("%s/%s",s.StorageLocation, sample.SHA256)
-	data, err := ioutil.ReadFile(filepath)
+	path := filepath.Join(s.StorageLocation, sample.SHA256)
+	data, err := ioutil.ReadFile(path)
 	sample.Data = data
 	return sample, err
 }


### PR DESCRIPTION
For testing purposes and smaller setups it is useful to have the option to use the local filesystem for object storage instead of a S3 cluster.
Additionally it is now possible to run the storer and objStorer setup in one command.
(./Holmes-Totem --setup --objSetup)