### PR TITLE
Correct values for "source", "submissions", and "obj_name"

### DIFF
--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -275,6 +275,9 @@ func (s StorerCassandra) StoreObject(object *storerGeneric.Object) error {
 			object.SHA256,
 		).Exec()
 	}
+	object.Source = source
+	object.ObjName = obj_name
+	object.Submissions = submission_ids
 
 	return err
 }


### PR DESCRIPTION
When the user requested to store an object, the fields "source", "submissions", and "obj_name" were aggregated from previous uploads of the same sample and then correctly stored in the database. The object returned to the uploader, however, only contained empty strings for these fields. This issue is tackled by this pull request.