### PR TITLE
Removed SASI Sparse and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ Holmes-Storage supports a single or cluster installation of Cassandra version 3.
 
 
 ###### Configuration
-New Cassandra clusters will need to be configured before Cassandra is started for the first time. We have highlighted a few of the configuration options that are critical or will increate performance. For additional options, please see the [Cassandra installition guide](http://cassandra.apache.org/doc/latest/getting_started/configuring.html#main-runtime-properties). 
+New Cassandra clusters will need to be configured before Cassandra is started for the first time. We have highlighted a few of the configuration options that are critical or will improve performance. For additional options, please see the [Cassandra instillation guide](http://cassandra.apache.org/doc/latest/getting_started/configuring.html#main-runtime-properties). 
 
 To edit these values, please open the Cassandra configuration file in your favorite editor. The Cassandra configuration file is typically located in `/etc/cassandra/cassandra.yaml`. 
 
 The Cassandra "cluster_name" must be set and the same on all nodes. The name you select does not much matter but again it should be identical on all nodes.
 `cluster_name: 'Holmes Processing'`
 
-Cassandra 3.x has an improved token allocation algorthim. As such, 256 is not necessary and should be decreased to 64 or 128 tokens. 
+Cassandra 3.x has an improved token allocation algorithm. As such, 256 is not necessary and should be decreased to 64 or 128 tokens. 
 `num_tokens: 128`
 
-You should populate the "seeds" value with the IP addresses for at least 2 additional Cassandra nodes.
+You should populate the "seeds" value with the IP addresses for at least two additional Cassandra nodes.
 `seeds: <ip node1>,<ip node2>`
 
 The "listen_address" should be set to the external IP address for the current Cassandra node.
-`listen_address`
+`listen_address: <external ip address>`
 
 ###### Best Practices
 On a new cluster, Holmes-Storage will setup the database in an optimal way for the average user. However, we recommend Cassandra users to please read the [Cassandra's Operations website](http://wiki.apache.org/cassandra/Operations) for more information Cassandra best practices.  Additionally, it is critical that the Cassandra cluster be regularly repaired using `nodetool repair` command. We recommend that this is executed on every node, one at a time, at least once a weekly.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,28 @@ We support two primary object storage databases. We recommend a Cassandra cluste
 ##### Cassandra 
 Holmes-Storage supports a single or cluster installation of Cassandra version 3.5.x and higher. The version requirement is because of the significant improvement in system performance when leveraging the newly introduced [SASIIndex](https://github.com/apache/cassandra/blob/trunk/doc/SASI.md) for secondary indexing. We highly recommend deploying Cassandra as a cluster with a minimum of three Cassandra nodes in production environments.
 
+###### Installation
+
+
 ###### Configuration
+New Cassandra clusters will need to be configured before Cassandra is started for the first time. We have highlighted a few of the configuration options that are critical or will increate performance. For additional options, please see the [Cassandra installition guide](http://cassandra.apache.org/doc/latest/getting_started/configuring.html#main-runtime-properties). 
+
+To edit these values, please open the Cassandra configuration file in your favorite editor. The Cassandra configuration file is typically located in `/etc/cassandra/cassandra.yaml`. 
+
+The Cassandra "cluster_name" must be set and the same on all nodes. The name you select does not much matter but again it should be identical on all nodes.
+`cluster_name: 'Holmes Processing'`
+
+Cassandra 3.x has an improved token allocation algorthim. As such, 256 is not necessary and should be decreased to 64 or 128 tokens. 
+`num_tokens: 128`
+
+You should populate the "seeds" value with the IP addresses for at least 2 additional Cassandra nodes.
+`seeds: <ip node1>,<ip node2>`
+
+The "listen_address" should be set to the external IP address for the current Cassandra node.
+`listen_address`
+
+###### Best Practices
+On a new cluster, Holmes-Storage will setup the database in an optimal way for the average user. However, we recommend Cassandra users to please read the [Cassandra's Operations website](http://wiki.apache.org/cassandra/Operations) for more information Cassandra best practices.  Additionally, it is critical that the Cassandra cluster be regularly repaired using `nodetool repair` command. We recommend that this is executed on every node, one at a time, at least once a weekly.
 
 ###### Indexing
 Holmes-Storage uses [SASIIndex](https://github.com/apache/cassandra/blob/trunk/doc/SASI.md) for indexing the Cassandra database. This indexing allows for querying of large datasets with minimal overhead. When leveraging Cassandra, most of the Holmes Processing tools will automatically use SASI indexes for speed improvements. Power users wishing to learn more about how to utilize these indexes should please visit the excellent blog post by [Doan DyuHai](http://www.doanduyhai.com/blog/?p=2058).

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -113,10 +113,7 @@ func (s StorerCassandra) Setup() error {
 	// Add SASI indexes for results
 	tableResultsIndex := `CREATE CUSTOM INDEX results_finished_date_time_idx 
 		ON holmes_testing.results (finished_date_time) 
-		USING 'org.apache.cassandra.index.sasi.SASIIndex' 
-		WITH OPTIONS = {
-			'mode' : 'SPARSE'
-		};`
+		USING 'org.apache.cassandra.index.sasi.SASIIndex';`
 	if err := s.DB.Query(tableResultsIndex).Exec(); err != nil {
 		return err
 	}
@@ -137,10 +134,7 @@ func (s StorerCassandra) Setup() error {
 
 	tableResultsIndex = `CREATE CUSTOM INDEX results_started_date_time_idx 
 		ON holmes_testing.results (started_date_time) 
-		USING 'org.apache.cassandra.index.sasi.SASIIndex' 
-		WITH OPTIONS = {
-			'mode' : 'SPARSE'
-		};`
+		USING 'org.apache.cassandra.index.sasi.SASIIndex';`
 	if err := s.DB.Query(tableResultsIndex).Exec(); err != nil {
 		return err
 	}
@@ -204,10 +198,7 @@ func (s StorerCassandra) Setup() error {
 
 	tableSubmissionsIndex = `CREATE CUSTOM INDEX submissions_date_idx 
 		ON holmes_testing.submissions (date) 
-		USING 'org.apache.cassandra.index.sasi.SASIIndex' 
-		WITH OPTIONS = {
-			'mode' : 'SPARSE'
-		};`
+		USING 'org.apache.cassandra.index.sasi.SASIIndex';`
 	if err := s.DB.Query(tableSubmissionsIndex).Exec(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Removed SASI Sparse indexing as Cassandra can receive multiple entries in the same time window. This could cause a conflict with the SASI system. Also, updated the README.md with best practices. 

Thanks DuyHai Doan!