### PR TITLE
Store configs in db

### DIFF
--- a/http.go
+++ b/http.go
@@ -38,6 +38,8 @@ func initHTTP(httpBinding string, eMime bool) {
 
 	router.GET("/samples/:sha256", httpSampleGet)
 	router.PUT("/samples/", httpSampleStore)
+	router.GET("/config/*path", httpConfigGet)
+	router.POST("/config/*path", httpConfigStore)
 
 	http.ListenAndServe(httpBinding, router)
 }
@@ -180,6 +182,49 @@ func httpSampleGet(w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	fmt.Fprint(w, string(sample.Data))
 }
+
+func httpConfigStore(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	path := strings.ToLower(ps.ByName("path"))
+	file, _, err := r.FormFile("config")
+	if err != nil {
+		httpFailure(w, r, err)
+		return
+	}
+	defer file.Close()
+
+	fileBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		httpFailure(w, r, err)
+		return
+	}
+
+	config := &storerGeneric.Config{
+		Path: path,
+		FileContents: string(fileBytes),
+	}
+
+	err = mainStorer.StoreConfig(config)
+	if err != nil {
+		httpFailure(w, r, err)
+		return
+	}
+
+	httpSuccess(w, r, path)
+}
+
+func httpConfigGet(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	config, err := mainStorer.GetConfig(strings.ToLower(ps.ByName("path")))
+
+	if err != nil {
+		httpFailure(w, r, err)
+		return
+	}
+
+	w.Header().Set("Content-Disposition", "attachment; filename="+config.Path)
+	w.Header().Set("Content-Type", "text/plain")
+	fmt.Fprint(w, string(config.FileContents))
+}
+
 
 func httpSuccess(w http.ResponseWriter, r *http.Request, result interface{}) {
 	j, err := json.Marshal(apiResponse{

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -54,6 +54,9 @@ func (s StorerCassandra) Setup() error {
 	if err := s.DB.Query("SELECT * FROM submissions LIMIT 1;").Exec(); err == nil {
 		return errors.New("Table submissions already exists, aborting!")
 	}
+	if err := s.DB.Query("SELECT * FROM config LIMIT 1;").Exec(); err == nil {
+		return errors.New("Table config already exists, aborting!")
+	}
 
 	// create tables
 	tableResults := `CREATE TABLE results(
@@ -104,6 +107,14 @@ func (s StorerCassandra) Setup() error {
 		comment text
 	);`
 	if err := s.DB.Query(tableSubmissions).Exec(); err != nil {
+		return err
+	}
+
+	tableConfig := `CREATE TABLE config(
+		path text PRIMARY KEY,
+		file_contents text
+	);`
+	if err := s.DB.Query(tableConfig).Exec(); err != nil {
 		return err
 	}
 
@@ -431,4 +442,24 @@ func (s StorerCassandra) GetResult(id string) (*storerGeneric.Result, error) {
 	)
 
 	return result, err
+}
+
+func (s StorerCassandra) StoreConfig(config *storerGeneric.Config) error {
+	err := s.DB.Query(`INSERT INTO config (path, file_contents) VALUES (?, ?)`,
+		config.Path,
+		config.FileContents,
+	).Exec()
+
+	return err
+}
+
+func (s StorerCassandra) GetConfig(path string) (*storerGeneric.Config, error) {
+	config := &storerGeneric.Config{}
+
+	err := s.DB.Query(`SELECT * FROM config WHERE path = ? LIMIT 1`, path).Scan(
+		&config.Path,
+		&config.FileContents,
+	)
+
+	return config, err
 }

--- a/storerGeneric/storerGeneric.go
+++ b/storerGeneric/storerGeneric.go
@@ -41,6 +41,9 @@ type Storer interface {
 
 	// Gets a result by Id from the database
 	GetResult(string) (*Result, error)
+
+	StoreConfig(*Config) error
+	GetConfig(string) (*Config, error)
 }
 
 type Object struct {
@@ -83,4 +86,9 @@ type Result struct {
 	WatchguardStatus  string    `json:"watchguard_status"`
 	WatchguardLog     []string  `json:"watchguard_log"`
 	WatchguardVersion string    `json:"watchguard_version"`
+}
+
+type Config struct {
+	Path         string `json:"path"`
+	FileContents string `json:"file_contents"`
 }

--- a/storerMongoDB/storerMongoDB.go
+++ b/storerMongoDB/storerMongoDB.go
@@ -253,3 +253,19 @@ func (s StorerMongoDB) GetResult(id string) (*storerGeneric.Result, error) {
 		WatchguardVersion: result.WatchguardVersion,
 	}, nil
 }
+
+func (s StorerMongoDB) StoreConfig(config *storerGeneric.Config) error {
+	err := s.DB.C("config").Insert(config)
+	return err
+}
+
+func (s StorerMongoDB) GetConfig(path string) (*storerGeneric.Config, error) {
+	var config storerGeneric.Config
+	s.DB.C("config").Find(bson.M{"path": path}).One(&config)
+
+	if config.Path == "" {
+		return nil, errors.New("Not found")
+	}
+
+	return &config, nil
+}


### PR DESCRIPTION
This pull request adds HTTP-handlers for GET and POST to "/config/<path>" which allow a user to upload and query configuration files, which are stored in the database.
A file is uploaded by using the POST-parameter "config". It is queried by using GET on the path which was used for uploading.