### PR TITLE
Threadsafe magicMime

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
-	"github.com/HolmesProcessing/Holmes-Storage/objStorerS3"
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerLocalFS"
+	"github.com/HolmesProcessing/Holmes-Storage/objStorerS3"
 	"github.com/HolmesProcessing/Holmes-Storage/storerCassandra"
 	"github.com/HolmesProcessing/Holmes-Storage/storerGeneric"
 	"github.com/HolmesProcessing/Holmes-Storage/storerMongoDB"
@@ -134,7 +134,7 @@ func main() {
 
 		info.Println("Object storage was setup without errors.")
 	}
-	
+
 	if setup || objSetup {
 		return // we don't want to execute this any further
 	}

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -3,11 +3,13 @@ package ObjStorerS3
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
@@ -24,7 +26,7 @@ func (s ObjStorerS3) Initialize(c []*objStorerGeneric.ObjDBConnector) (objStorer
 		return nil, errors.New("Supply at least one node to connect to!")
 	}
 
-	s.DB = s3.New(session.New(&aws.Config{
+	s3sess, err := session.NewSession(&aws.Config{
 		Credentials: credentials.NewStaticCredentials(
 			c[0].Key,
 			c[0].Secret,
@@ -33,14 +35,19 @@ func (s ObjStorerS3) Initialize(c []*objStorerGeneric.ObjDBConnector) (objStorer
 		Region:           aws.String(c[0].Region),
 		S3ForcePathStyle: aws.Bool(true),
 		DisableSSL:       aws.Bool(c[0].DisableSSL),
-	}))
+	})
 
+	if err != nil {
+		return nil, err //same as Must(...)
+	}
+
+	s.DB = s3.New(s3sess)
 	s.Bucket = c[0].Bucket
 
 	// since there is no definit way to test the connection
 	// we are just doint a dummy request here to see if the
 	// connection is stable
-	_, err := s.DB.ListBuckets(&s3.ListBucketsInput{})
+	_, err = s.DB.ListBuckets(&s3.ListBucketsInput{})
 	return s, err
 }
 

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -3,13 +3,11 @@ package ObjStorerS3
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 


### PR DESCRIPTION
Even tough a mutex was used magicMime was still not thread safe thanks to a possible panic. This resulted in a never unlocking mutex. This pull fixes the issue by giving mM the change to recover and retry.