### PR TITLE
Detect and remove orphans

### DIFF
--- a/http.go
+++ b/http.go
@@ -324,7 +324,10 @@ func httpMainStorerGetSubmissions(w http.ResponseWriter, r *http.Request, ps htt
 // S: sample is in mainStorer-submissions
 // i.e. actionMS is executed, if a sample is only in mainStorer-objects (M) and mainStorer-submissions (S), but not in objStorer.
 func httpGetOrphans(actionOMS func(string), actionOM func(string), actionOS func(string), actionO func(string), actionMS func(string), actionM func(string), actionS func(string)) error {
-	MObjs := mainStorer.GetObjIterator()
+	MObjs, err := mainStorer.GetObjMap()
+	if err != nil {
+		return err
+	}
 
 	OObjs, err := objStorer.GetObjMap()
 	if err != nil {
@@ -341,9 +344,7 @@ func httpGetOrphans(actionOMS func(string), actionOM func(string), actionOS func
 	// iterate over the mainStorer-objects and try to find in
 	// objStorer and mainStorer-submissions
 	// Discard, if any entry is younger than an hour
-	var objM string
-	var tM time.Time
-	for MObjs(&objM, &tM) {
+	for objM, tM := range MObjs {
 		if tM.Before(t) {
 			tO, existsO := OObjs[objM]
 			tS, existsS := SObjs[objM]

--- a/http.go
+++ b/http.go
@@ -43,6 +43,9 @@ func initHTTP(httpBinding string, eMime bool) {
 	router.PUT("/samples/", httpSampleStore)
 	router.GET("/config/*path", httpConfigGet)
 	router.POST("/config/*path", httpConfigStore)
+	router.GET("/maintenance/listObjStorerObjs", httpObjStorerGetObjs)
+	router.GET("/maintenance/listOrphans", httpListOrphans)
+	router.POST("/maintenance/deleteOrphans", httpDeleteOrphans)
 
 	http.ListenAndServe(httpBinding, router)
 }
@@ -259,6 +262,30 @@ func httpSuccess(w http.ResponseWriter, r *http.Request, result interface{}) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(j)
+}
+
+// httpObjStorerGetObjs gathers a list of objects from the object-storer
+// and writes a json list of sha256-values to the ResponseWriter.
+func httpObjStorerGetObjs(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	objs, err := objStorer.GetObjList()
+	if err != nil {
+		httpFailure(w, r, err)
+	}
+
+	objsM, err := json.Marshal(objs)
+	if err != nil {
+		httpFailure(w, r, err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(objsM)
+}
+
+func httpListOrphans(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// TODO
+}
+func httpDeleteOrphans(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	// TODO
 }
 
 // httpErrorCode sends an HTTP Error back as a response to the request.

--- a/http.go
+++ b/http.go
@@ -266,20 +266,22 @@ func httpSuccess(w http.ResponseWriter, r *http.Request, result interface{}) {
 }
 
 // httpReturnObjs is just a helper-function which transforms the given objects to a list and writes them to the http-Response
-func httpReturnObjs(w http.ResponseWriter, r *http.Request, ps httprouter.Params, objs map[string]struct{}, err error) {
+func httpReturnObjs(w http.ResponseWriter, r *http.Request, ps httprouter.Params, objs map[string]time.Time, err error) {
 	if err != nil {
 		httpFailure(w, r, err)
 	}
+	/*
+		// transform to list, so it is better readable
+		objsL := make([]string, len(objs))
+		i := 0
+		for o := range objs {
+			objsL[i] = o
+			i++
+		}
 
-	// transform to list, so it is better readable
-	objsL := make([]string, len(objs))
-	i := 0
-	for o := range objs {
-		objsL[i] = o
-		i++
-	}
-
-	objsM, err := json.Marshal(objsL)
+		objsM, err := json.Marshal(objsL)
+	*/
+	objsM, err := json.Marshal(objs)
 	if err != nil {
 		httpFailure(w, r, err)
 	}

--- a/objStorerGeneric/objStorerGeneric.go
+++ b/objStorerGeneric/objStorerGeneric.go
@@ -37,6 +37,9 @@ type ObjStorer interface {
 
 	// Delete a sample from the database
 	DeleteSample(*Sample) error
+
+	// Get a list of all the sha256-values of the objects
+	GetObjList() ([]string, error)
 }
 
 // TODO: switch from json to probably raw bytes

--- a/objStorerGeneric/objStorerGeneric.go
+++ b/objStorerGeneric/objStorerGeneric.go
@@ -38,8 +38,8 @@ type ObjStorer interface {
 	// Delete a sample from the database
 	DeleteSample(*Sample) error
 
-	// Get a list of all the sha256-values of the objects
-	GetObjList() ([]string, error)
+	// Get a map of all the sha256-values of the objects
+	GetObjMap() (map[string]struct{}, error)
 }
 
 // TODO: switch from json to probably raw bytes

--- a/objStorerGeneric/objStorerGeneric.go
+++ b/objStorerGeneric/objStorerGeneric.go
@@ -39,6 +39,7 @@ type ObjStorer interface {
 
 	// Delete a sample from the database
 	DeleteSample(*Sample) error
+	DeleteSampleWithId(string) error
 
 	// Get a map of all the sha256-values of the objects to their corresponding upload-time
 	GetObjMap() (map[string]time.Time, error)

--- a/objStorerGeneric/objStorerGeneric.go
+++ b/objStorerGeneric/objStorerGeneric.go
@@ -1,5 +1,7 @@
 package objStorerGeneric
 
+import "time"
+
 /*
 This file contains structs to represent all default
 collections and interfaces.
@@ -38,8 +40,8 @@ type ObjStorer interface {
 	// Delete a sample from the database
 	DeleteSample(*Sample) error
 
-	// Get a map of all the sha256-values of the objects
-	GetObjMap() (map[string]struct{}, error)
+	// Get a map of all the sha256-values of the objects to their corresponding upload-time
+	GetObjMap() (map[string]time.Time, error)
 }
 
 // TODO: switch from json to probably raw bytes

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -67,7 +67,11 @@ func (s ObjStorerLocalFS) Setup() error {
 }
 
 func (s ObjStorerLocalFS) DeleteSample(sample *objStorerGeneric.Sample) error {
-	path := filepath.Join(s.StorageLocation, sample.SHA256)
+	return s.DeleteSampleWithId(sample.SHA256)
+}
+
+func (s ObjStorerLocalFS) DeleteSampleWithId(id string) error {
+	path := filepath.Join(s.StorageLocation, id)
 	err := os.Remove(path)
 	return err
 }

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -92,4 +92,15 @@ func (s ObjStorerLocalFS) GetSample(id string) (*objStorerGeneric.Sample, error)
 	return sample, err
 }
 
+func (s ObjStorerLocalFS) GetObjList() ([]string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	os.Chdir(s.StorageLocation)
+	ret, err := filepath.Glob("*")
+	os.Chdir(wd)
+	return ret, err
+}
+
 // TODO: Support MultipleObjects retrieval and getting. Useful when using something over 100megs

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
 )
@@ -92,7 +93,7 @@ func (s ObjStorerLocalFS) GetSample(id string) (*objStorerGeneric.Sample, error)
 	return sample, err
 }
 
-func (s ObjStorerLocalFS) GetObjMap() (map[string]struct{}, error) {
+func (s ObjStorerLocalFS) GetObjMap() (map[string]time.Time, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -100,9 +101,9 @@ func (s ObjStorerLocalFS) GetObjMap() (map[string]struct{}, error) {
 	os.Chdir(s.StorageLocation)
 	ret, err := filepath.Glob("*")
 	os.Chdir(wd)
-	retM := make(map[string]struct{})
+	retM := make(map[string]time.Time)
 	for _, i := range ret {
-		retM[i] = struct{}{}
+		retM[i] = time.Now() //TODO!!!
 	}
 	return retM, err
 }

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -99,11 +99,18 @@ func (s ObjStorerLocalFS) GetObjMap() (map[string]time.Time, error) {
 		return nil, err
 	}
 	os.Chdir(s.StorageLocation)
+	defer os.Chdir(wd)
 	ret, err := filepath.Glob("*")
-	os.Chdir(wd)
+	if err != nil {
+		return nil, err
+	}
 	retM := make(map[string]time.Time)
 	for _, i := range ret {
-		retM[i] = time.Now() //TODO!!!
+		info, err := os.Stat(i)
+		if err != nil {
+			return nil, err
+		}
+		retM[i] = info.ModTime()
 	}
 	return retM, err
 }

--- a/objStorerLocalFS/objStorerLocalFS.go
+++ b/objStorerLocalFS/objStorerLocalFS.go
@@ -92,7 +92,7 @@ func (s ObjStorerLocalFS) GetSample(id string) (*objStorerGeneric.Sample, error)
 	return sample, err
 }
 
-func (s ObjStorerLocalFS) GetObjList() ([]string, error) {
+func (s ObjStorerLocalFS) GetObjMap() (map[string]struct{}, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -100,7 +100,11 @@ func (s ObjStorerLocalFS) GetObjList() ([]string, error) {
 	os.Chdir(s.StorageLocation)
 	ret, err := filepath.Glob("*")
 	os.Chdir(wd)
-	return ret, err
+	retM := make(map[string]struct{})
+	for _, i := range ret {
+		retM[i] = struct{}{}
+	}
+	return retM, err
 }
 
 // TODO: Support MultipleObjects retrieval and getting. Useful when using something over 100megs

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -13,7 +13,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
-	"log"
 )
 
 type ObjStorerS3 struct {

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -123,7 +123,7 @@ func (s ObjStorerS3) GetObjMap() (map[string]time.Time, error) {
 	// ListObjects can only get a max of 1000 objs, so we need to do this in a loop
 	cont := true
 	params := &s3.ListObjectsInput{
-		Bucket:  aws.String("holmes"),
+		Bucket:  aws.String(s.Bucket),
 		MaxKeys: aws.Int64(1000),
 	}
 	for cont {
@@ -138,7 +138,7 @@ func (s ObjStorerS3) GetObjMap() (map[string]time.Time, error) {
 		params.Marker = resp.Contents[len(resp.Contents)-1].Key
 		cont = *resp.IsTruncated
 	}
-	log.Println(len(retM))
+	//log.Println(len(retM))
 	return retM, nil
 }
 

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -76,9 +76,13 @@ func (s ObjStorerS3) Setup() error {
 }
 
 func (s ObjStorerS3) DeleteSample(sample *objStorerGeneric.Sample) error {
+	return s.DeleteSampleWithId(sample.SHA256)
+}
+
+func (s ObjStorerS3) DeleteSampleWithId(id string) error {
 	_, err := s.DB.DeleteObject(&s3.DeleteObjectInput{
 		Bucket: &s.Bucket,
-		Key:    &sample.SHA256,
+		Key:    &id,
 	})
 
 	return err

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -111,7 +111,7 @@ func (s ObjStorerS3) GetSample(id string) (*objStorerGeneric.Sample, error) {
 	return sample, err
 }
 
-func (s ObjStorerS3) GetObjList() ([]string, error) {
+func (s ObjStorerS3) GetObjMap() (map[string]struct{}, error) {
 	//TODO!!!
 	return nil, nil
 }

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 
 	"github.com/HolmesProcessing/Holmes-Storage/objStorerGeneric"
+	"log"
 )
 
 type ObjStorerS3 struct {
@@ -112,8 +113,17 @@ func (s ObjStorerS3) GetSample(id string) (*objStorerGeneric.Sample, error) {
 }
 
 func (s ObjStorerS3) GetObjMap() (map[string]struct{}, error) {
-	//TODO!!!
-	return nil, nil
+	//TODO: ListObjectsInput claims to only get a max of 1000 objs
+	params := &s3.ListObjectsInput{
+		Bucket: aws.String("holmes"),
+	}
+	resp, err := s.DB.ListObjects(params)
+	retM := make(map[string]struct{})
+	for _, c := range resp.Contents {
+		retM[*(c.Key)] = struct{}{}
+	}
+	log.Println(len(retM))
+	return retM, err
 }
 
 // TODO: Support MultipleObjects retrieval and getting. Useful when using something over 100megs

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -111,4 +111,9 @@ func (s ObjStorerS3) GetSample(id string) (*objStorerGeneric.Sample, error) {
 	return sample, err
 }
 
+func (s ObjStorerS3) GetObjList() ([]string, error) {
+	//TODO!!!
+	return nil, nil
+}
+
 // TODO: Support MultipleObjects retrieval and getting. Useful when using something over 100megs

--- a/objStorerS3/objStorerS3.go
+++ b/objStorerS3/objStorerS3.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -112,8 +113,8 @@ func (s ObjStorerS3) GetSample(id string) (*objStorerGeneric.Sample, error) {
 	return sample, err
 }
 
-func (s ObjStorerS3) GetObjMap() (map[string]struct{}, error) {
-	retM := make(map[string]struct{})
+func (s ObjStorerS3) GetObjMap() (map[string]time.Time, error) {
+	retM := make(map[string]time.Time)
 
 	// ListObjects can only get a max of 1000 objs, so we need to do this in a loop
 	cont := true
@@ -127,7 +128,7 @@ func (s ObjStorerS3) GetObjMap() (map[string]struct{}, error) {
 			return retM, err
 		}
 		for _, c := range resp.Contents {
-			retM[*(c.Key)] = struct{}{}
+			retM[*(c.Key)] = *c.LastModified
 		}
 
 		params.Marker = resp.Contents[len(resp.Contents)-1].Key

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -364,6 +364,26 @@ func (s StorerCassandra) GetObject(id string) (*storerGeneric.Object, error) {
 	return object, err
 }
 
+func (s StorerCassandra) GetObjMap() (map[string]struct{}, error) {
+	//shas := make([]string, 0)
+	shas := make(map[string]struct{})
+	sha256 := ""
+
+	iter := s.DB.Query(`SELECT sha256 FROM objects`).Iter()
+	for iter.Scan(
+		&sha256,
+	) {
+		/*shas = append(shas, sha256)
+		sha256 = ""*/
+		shas[sha256] = struct{}{}
+	}
+
+	err := iter.Close()
+
+	return shas, err
+
+}
+
 func (s StorerCassandra) UpdateObject(id string) error {
 	submissions, err := s.GetSubmissionsByObject(id)
 	if err != nil {

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -516,6 +516,15 @@ func (s StorerCassandra) GetSubmissionsByObject(sha256 string) ([]*storerGeneric
 	return submissions, err
 }
 
+func (s StorerCassandra) DeleteAllSubmissionsOfObject(id string) error {
+	return s.DB.Query(`DELETE FROM submissions WHERE sha256 = ?`, id).Exec()
+}
+
+func (s StorerCassandra) DeleteSampleAndSubmissions(id string) {
+	s.DeleteObject(id)
+	s.DeleteAllSubmissionsOfObject(id)
+}
+
 func (s StorerCassandra) StoreResult(result *storerGeneric.Result) error {
 	id, err := gocql.RandomUUID()
 	if err != nil {

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -365,7 +365,6 @@ func (s StorerCassandra) GetObject(id string) (*storerGeneric.Object, error) {
 }
 
 func (s StorerCassandra) GetObjMap() (map[string]struct{}, error) {
-	//shas := make([]string, 0)
 	shas := make(map[string]struct{})
 	sha256 := ""
 
@@ -373,8 +372,6 @@ func (s StorerCassandra) GetObjMap() (map[string]struct{}, error) {
 	for iter.Scan(
 		&sha256,
 	) {
-		/*shas = append(shas, sha256)
-		sha256 = ""*/
 		shas[sha256] = struct{}{}
 	}
 

--- a/storerCassandra/storerCassandra.go
+++ b/storerCassandra/storerCassandra.go
@@ -373,7 +373,7 @@ func (s StorerCassandra) GetObjMap() (map[string]time.Time, error) {
 	for iter.Scan(
 		&sha256,
 	) {
-		shas[sha256] = time.Now() //TODO
+		shas[sha256] = time.Time{} //TODO
 	}
 
 	err := iter.Close()
@@ -387,7 +387,7 @@ func (s StorerCassandra) GetSubmissionMap() (map[string]time.Time, error) {
 	sha256 := ""
 	var date time.Time
 
-	iter := s.DB.Query(`SELECT sha256, date FROM objects`).Iter()
+	iter := s.DB.Query(`SELECT sha256, date FROM submissions`).Iter()
 	for iter.Scan(
 		&sha256,
 		&date,

--- a/storerGeneric/storerGeneric.go
+++ b/storerGeneric/storerGeneric.go
@@ -37,6 +37,7 @@ type Storer interface {
 	StoreObject(*Object) (bool, error)
 	DeleteObject(string) error
 	GetObject(string) (*Object, error)
+	GetObjMap() (map[string]struct{}, error)
 
 	// Gather all the submissions for the object, extract the filenames
 	// and the sources and store them in the object

--- a/storerGeneric/storerGeneric.go
+++ b/storerGeneric/storerGeneric.go
@@ -37,7 +37,9 @@ type Storer interface {
 	StoreObject(*Object) (bool, error)
 	DeleteObject(string) error
 	GetObject(string) (*Object, error)
-	GetObjMap() (map[string]struct{}, error)
+	GetObjMap() (map[string]time.Time, error)
+	// Map the SHA256 to the first submission
+	GetSubmissionMap() (map[string]time.Time, error)
 
 	// Gather all the submissions for the object, extract the filenames
 	// and the sources and store them in the object

--- a/storerGeneric/storerGeneric.go
+++ b/storerGeneric/storerGeneric.go
@@ -38,6 +38,7 @@ type Storer interface {
 	DeleteObject(string) error
 	GetObject(string) (*Object, error)
 	GetObjMap() (map[string]time.Time, error)
+	GetObjIterator() func(*string, *time.Time) bool
 	// Map the SHA256 to the first submission
 	GetSubmissionMap() (map[string]time.Time, error)
 

--- a/storerGeneric/storerGeneric.go
+++ b/storerGeneric/storerGeneric.go
@@ -47,7 +47,12 @@ type Storer interface {
 
 	StoreSubmission(*Submission) error
 	DeleteSubmission(string) error
+	DeleteAllSubmissionsOfObject(string) error
 	GetSubmission(string) (*Submission, error)
+
+	// Delete a sample and all of its submissions (the sample neither has
+	// to be in the objects-table nor in the submissions-table)
+	DeleteSampleAndSubmissions(string)
 
 	// Stores a result in the database
 	// (TODO: return generated Id)

--- a/storerMongoDB/storerMongoDB.go
+++ b/storerMongoDB/storerMongoDB.go
@@ -160,8 +160,16 @@ func (s StorerMongoDB) GetObject(id string) (*storerGeneric.Object, error) {
 }
 
 func (s StorerMongoDB) GetObjMap() (map[string]struct{}, error) {
-	//TODO!!!
-	return nil, nil
+	shas := make(map[string]struct{})
+	iter := s.DB.C("objects").Find(nil).Select(bson.M{"sha256": true}).Iter()
+	result := bson.M{}
+	for iter.Next(&result) {
+		shas[result["sha256"].(string)] = struct{}{}
+	}
+
+	err := iter.Close()
+
+	return shas, err
 }
 
 func (s StorerMongoDB) UpdateObject(id string) error {

--- a/storerMongoDB/storerMongoDB.go
+++ b/storerMongoDB/storerMongoDB.go
@@ -159,6 +159,11 @@ func (s StorerMongoDB) GetObject(id string) (*storerGeneric.Object, error) {
 	return &object, nil
 }
 
+func (s StorerMongoDB) GetObjMap() (map[string]struct{}, error) {
+	//TODO!!!
+	return nil, nil
+}
+
 func (s StorerMongoDB) UpdateObject(id string) error {
 	submissions := s.GetSubmissionsByObject(id)
 	l := len(submissions)

--- a/storerMongoDB/storerMongoDB.go
+++ b/storerMongoDB/storerMongoDB.go
@@ -267,7 +267,15 @@ func (s StorerMongoDB) GetSubmissionsByObject(sha256 string) []*Submission {
 	submissions := []*Submission{}
 	s.DB.C("submissions").Find(bson.M{"sha256": sha256}).All(&submissions)
 	return submissions
+}
 
+func (s StorerMongoDB) DeleteAllSubmissionsOfObject(id string) error {
+	return s.DB.C("submissions").Remove(bson.M{"sha256": id})
+}
+
+func (s StorerMongoDB) DeleteSampleAndSubmissions(id string) {
+	s.DeleteObject(id)
+	s.DeleteAllSubmissionsOfObject(id)
 }
 
 func (s StorerMongoDB) StoreResult(result *storerGeneric.Result) error {


### PR DESCRIPTION
This pull-request closes https://github.com/HolmesProcessing/Holmes-Storage/issues/41. For this purpose, it adds the following new HTTP-Handlers:
GET:

- /maintenance/listObjStorerObjs
- /maintenance/listMainStorerObjs
- /maintenance/listMainStorerSubmissions
- /maintenance/listOrphans

POST:

- /maintenance/deleteOrphans

All the GET-handlers are only for informational purposes. In order to remove orphans, it is enough to just POST to the last handler. It cross compares all the objects in the objStorer, objects in the objects-table of the mainStorer, and objects in the submissions-table of the mainStorer.
If any sample does not exist in any of these three locations, it is removed from all of them.
Only samples that are at least one hour old, are taken into account, in order to prevent false positives while still uploading.
(strictly speaking, the objects-table has no sample-time yet (https://github.com/HolmesProcessing/Holmes-Storage/issues/32#issuecomment-266109767). However, since samples are always first inserted into the submissions-table, samples that are ONLY in the objects-table, but not in the submissions-table must be orphans, so they are treated as such)